### PR TITLE
feat: add stock sub-type support and fix water nav

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -2,14 +2,10 @@ import { useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { setLanguage } from '../../i18n'
-import { useProducts } from '../../hooks/useProducts'
 
 export default function Navbar() {
   const { t, i18n } = useTranslation()
-  const { data: products = [] } = useProducts()
   const [menuOpen, setMenuOpen] = useState(false)
-
-  const waterProduct = products.find((p) => p.category === 'WATER')
 
   const linkClass = ({ isActive }: { isActive: boolean }) =>
     `px-3 py-2 rounded-md text-sm font-medium transition-colors ${isActive
@@ -37,11 +33,9 @@ export default function Navbar() {
             <NavLink to="/food" className={linkClass}>
               🥫 {t('nav.products')}
             </NavLink>
-            {waterProduct && (
-              <NavLink to="/water" className={linkClass}>
-                💧 {t('nav.water')}
-              </NavLink>
-            )}
+            <NavLink to="/water" className={linkClass}>
+              💧 {t('nav.water')}
+            </NavLink>
           </div>
 
           {/* Language switcher + hamburger */}
@@ -86,11 +80,9 @@ export default function Navbar() {
             <NavLink to="/food" className={mobileLinkClass}>
               🥫 {t('nav.products')}
             </NavLink>
-            {waterProduct && (
-              <NavLink to="/water" className={mobileLinkClass}>
-                💧 {t('nav.water')}
-              </NavLink>
-            )}
+            <NavLink to="/water" className={mobileLinkClass}>
+              💧 {t('nav.water')}
+            </NavLink>
           </div>
         )}
       </div>

--- a/src/components/stock/StockEntryForm.tsx
+++ b/src/components/stock/StockEntryForm.tsx
@@ -8,6 +8,7 @@ interface Props {
   isLoading?: boolean
   error?: string | null
   hideExpiryDate?: boolean
+  showSubType?: boolean
 }
 
 function today() {
@@ -20,9 +21,10 @@ function getExpiryDate(baseDate: string, monthsToAdd: number) {
   return d.toISOString().slice(0, 10)
 }
 
-export default function StockEntryForm({ unit, onSubmit, isLoading, error, hideExpiryDate }: Props) {
+export default function StockEntryForm({ unit, onSubmit, isLoading, error, hideExpiryDate, showSubType }: Props) {
   const { t } = useTranslation()
   const [quantity, setQuantity] = useState('')
+  const [subType, setSubType] = useState('')
   const [purchasedDate, setPurchasedDate] = useState(today())
   const [expiryDate, setExpiryDate] = useState(hideExpiryDate ? getExpiryDate(today(), 6) : '')
   const [location, setLocation] = useState('')
@@ -32,6 +34,7 @@ export default function StockEntryForm({ unit, onSubmit, isLoading, error, hideE
     e.preventDefault()
     onSubmit({
       quantity: parseFloat(quantity),
+      subType: showSubType ? (subType.trim() || null) : undefined,
       purchasedDate,
       expiryDate: hideExpiryDate ? getExpiryDate(purchasedDate, 6) : expiryDate,
       location: location.trim() || null,
@@ -65,6 +68,18 @@ export default function StockEntryForm({ unit, onSubmit, isLoading, error, hideE
           required
         />
       </div>
+
+      {showSubType && (
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">{t('stock_form.sub_type_label')}</label>
+          <input
+            className={inputClass}
+            value={subType}
+            onChange={(e) => setSubType(e.target.value)}
+            placeholder={t('stock_form.sub_type_placeholder')}
+          />
+        </div>
+      )}
 
       <div>
         <label className="block text-sm text-gray-400 mb-1">{t('stock_form.purchased_date_label')}</label>

--- a/src/components/stock/StockEntryRow.tsx
+++ b/src/components/stock/StockEntryRow.tsx
@@ -59,6 +59,12 @@ export default function StockEntryRow({
           <span className="text-gray-400">{t('stock_entry.location_label')}</span>
           <p className="text-white">{entry.location ?? '—'}</p>
         </div>
+        {entry.subType && (
+          <div className="col-span-2">
+            <span className="text-gray-400">{t('stock_entry.sub_type_label')}</span>
+            <p className="text-white">{entry.subType}</p>
+          </div>
+        )}
         <div>
           <span className="text-gray-400">{t('stock_entry.purchased_label')}</span>
           <p className="text-white">{formatDate(entry.purchasedDate)}</p>

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -81,6 +81,8 @@ const en = {
     modal_title: 'Add stock batch',
     quantity_label: 'Quantity ({{unit}})',
     quantity_placeholder: 'e.g. 40',
+    sub_type_label: 'Variant (optional)',
+    sub_type_placeholder: 'e.g. Penne pasta',
     purchased_date_label: 'Purchase date',
     expiry_date_label: 'Expiry date',
     location_label: 'Location (optional)',
@@ -92,6 +94,7 @@ const en = {
   stock_entry: {
     consume_next: 'Consume next',
     quantity_label: 'Quantity',
+    sub_type_label: 'Variant',
     location_label: 'Location',
     purchased_label: 'Purchased',
     expires_label: 'Expires',

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -81,6 +81,8 @@ const sv = {
     modal_title: 'Lägg till lagerbatch',
     quantity_label: 'Kvantitet ({{unit}})',
     quantity_placeholder: 'ex. 40',
+    sub_type_label: 'Variant (valfritt)',
+    sub_type_placeholder: 'ex. Penne pasta',
     purchased_date_label: 'Inköpsdatum',
     expiry_date_label: 'Utgångsdatum',
     location_label: 'Plats (valfritt)',
@@ -92,6 +94,7 @@ const sv = {
   stock_entry: {
     consume_next: 'Konsumera härnäst',
     quantity_label: 'Kvantitet',
+    sub_type_label: 'Variant',
     location_label: 'Plats',
     purchased_label: 'Inköpt',
     expires_label: 'Utgår',

--- a/src/pages/FoodDetailPage.tsx
+++ b/src/pages/FoodDetailPage.tsx
@@ -169,6 +169,7 @@ export default function FoodDetailPage({ forceId }: Props) {
             onSubmit={handleAddStock}
             isLoading={addStock.isPending}
             error={addStockError}
+            showSubType
           />
         </Modal>
       )}

--- a/src/pages/WaterPage.tsx
+++ b/src/pages/WaterPage.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
 import { useProducts } from '../hooks/useProducts'
 import WaterDetailPage from './WaterDetailPage'
+import WaterWidget from '../components/dashboard/WaterWidget'
 
 export default function WaterPage() {
     const { t } = useTranslation()
@@ -13,14 +13,7 @@ export default function WaterPage() {
     const waterProduct = products.find((p) => p.category === 'WATER')
 
     if (!waterProduct) {
-        return (
-            <div className="text-center py-16">
-                <p className="text-red-400">{t('products.not_found')}</p>
-                <Link to="/" className="text-green-400 hover:underline text-sm mt-2 block">
-                    {t('not_found.cta')}
-                </Link>
-            </div>
-        )
+        return <WaterWidget />
     }
 
     return <WaterDetailPage forceId={waterProduct.id} />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,6 +42,7 @@ export interface StockEntry {
   id: number
   productId: number
   quantity: number
+  subType: string | null
   purchasedDate: string
   expiryDate: string
   location: string | null
@@ -59,6 +60,7 @@ export interface ProductPayload {
 
 export interface StockEntryPayload {
   quantity: number
+  subType?: string | null
   purchasedDate: string
   expiryDate: string
   location?: string | null


### PR DESCRIPTION
## Summary
- Add optional `subType` (variant) field to stock entries — shown in the add-batch form for food items (e.g. "Penne pasta" for a Pasta product) and displayed in the stock entry row when set
- Always show the Water nav link instead of hiding it until a water product exists
- Replace the misleading "Food not found" error on `/water` with the WaterWidget setup UI when no water product has been configured yet

## Test plan
- [ ] Add a food product (e.g. "Pasta"), open it, add a batch with a variant (e.g. "Penne pasta") — variant should appear in the batch list
- [ ] Add a batch without a variant — row should display normally without a variant row
- [ ] Water link visible in navbar on desktop without needing a water product set up
- [ ] Navigating to `/water` before setup shows the setup widget; after setup shows the water detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)