### PR TITLE
fix: make stock entry dates optional per updated API spec

### DIFF
--- a/src/components/stock/StockEntryForm.tsx
+++ b/src/components/stock/StockEntryForm.tsx
@@ -35,8 +35,8 @@ export default function StockEntryForm({ unit, onSubmit, isLoading, error, hideE
     onSubmit({
       quantity: parseFloat(quantity),
       subType: showSubType ? (subType.trim() || null) : undefined,
-      purchasedDate,
-      expiryDate: hideExpiryDate ? getExpiryDate(purchasedDate, 6) : expiryDate,
+      purchasedDate: purchasedDate || null,
+      expiryDate: hideExpiryDate ? getExpiryDate(purchasedDate || today(), 6) : (expiryDate || null),
       location: location.trim() || null,
       notes: notes.trim() || null,
     })
@@ -88,7 +88,6 @@ export default function StockEntryForm({ unit, onSubmit, isLoading, error, hideE
           type="date"
           value={purchasedDate}
           onChange={(e) => setPurchasedDate(e.target.value)}
-          required
         />
       </div>
 
@@ -100,7 +99,6 @@ export default function StockEntryForm({ unit, onSubmit, isLoading, error, hideE
             type="date"
             value={expiryDate}
             onChange={(e) => setExpiryDate(e.target.value)}
-            required
           />
         </div>
       )}

--- a/src/components/stock/StockEntryRow.tsx
+++ b/src/components/stock/StockEntryRow.tsx
@@ -35,7 +35,7 @@ export default function StockEntryRow({
 
   const actionColor =
     entry.recommendedAction
-      ? entry.expiryDate < new Date().toISOString().slice(0, 10)
+      ? entry.expiryDate && entry.expiryDate < new Date().toISOString().slice(0, 10)
         ? 'text-red-400 bg-red-900/20 border border-red-800'
         : 'text-yellow-400 bg-yellow-900/20 border border-yellow-800'
       : ''
@@ -67,11 +67,11 @@ export default function StockEntryRow({
         )}
         <div>
           <span className="text-gray-400">{t('stock_entry.purchased_label')}</span>
-          <p className="text-white">{formatDate(entry.purchasedDate)}</p>
+          <p className="text-white">{entry.purchasedDate ? formatDate(entry.purchasedDate) : '—'}</p>
         </div>
         <div>
           <span className="text-gray-400">{t('stock_entry.expires_label')}</span>
-          <p className="text-white">{formatDate(entry.expiryDate)}</p>
+          <p className="text-white">{entry.expiryDate ? formatDate(entry.expiryDate) : '—'}</p>
         </div>
       </div>
 

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -33,7 +33,7 @@ function StockAlertRow({
             {product?.name ?? t('dashboard.product_fallback', { id: entry.productId })}
           </Link>
           <p className="text-sm text-gray-400 mt-0.5">
-            {entry.quantity} {unit} · {t('dashboard.expires', { date: formatDate(entry.expiryDate) })}
+            {entry.quantity} {unit}{entry.expiryDate && ` · ${t('dashboard.expires', { date: formatDate(entry.expiryDate) })}`}
             {entry.location && ` · ${entry.location}`}
           </p>
           {entry.recommendedAction && (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,8 +43,8 @@ export interface StockEntry {
   productId: number
   quantity: number
   subType: string | null
-  purchasedDate: string
-  expiryDate: string
+  purchasedDate: string | null
+  expiryDate: string | null
   location: string | null
   notes: string | null
   recommendedAction: string | null
@@ -61,8 +61,8 @@ export interface ProductPayload {
 export interface StockEntryPayload {
   quantity: number
   subType?: string | null
-  purchasedDate: string
-  expiryDate: string
+  purchasedDate?: string | null
+  expiryDate?: string | null
   location?: string | null
   notes?: string | null
 }


### PR DESCRIPTION
## Summary
- `purchasedDate` and `expiryDate` are no longer required fields on `StockEntryRequest` in the backend API
- Updated `StockEntry` response type to `string | null` for both date fields
- Updated `StockEntryPayload` to mark both dates as optional
- Removed `required` attribute from date inputs in `StockEntryForm`
- `StockEntryRow` falls back to `—` when dates are null
- `DashboardPage` skips the "Expires …" label when `expiryDate` is null

## Test plan
- [ ] Add a stock batch without filling in either date — should save successfully
- [ ] Stock entry rows with no dates show `—` for purchased/expires fields
- [ ] Dashboard alert rows with no expiry date omit the "Expires …" part
- [ ] Existing entries with dates still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)