### PR TITLE
feat: compact edit/delete buttons inline with product label

### DIFF
--- a/src/pages/FoodDetailPage.tsx
+++ b/src/pages/FoodDetailPage.tsx
@@ -83,32 +83,30 @@ export default function FoodDetailPage({ forceId }: Props) {
 
       {/* Product header */}
       <div className="bg-gray-800 border border-gray-700 rounded-xl p-4 sm:p-6 mb-6">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="min-w-0">
-            <h1 className="text-xl sm:text-2xl font-bold text-white">{product.name}</h1>
-            <p className="text-gray-400 text-sm mt-1">
+        <div>
+          <h1 className="text-xl sm:text-2xl font-bold text-white">{product.name}</h1>
+          <div className="flex items-center gap-2 mt-1">
+            <p className="text-gray-400 text-sm">
               {t(`categories.${product.category}`)} · {t('products.target', { qty: product.targetQuantity, unit })}
             </p>
-            {product.notes && (
-              <p className="text-gray-300 text-sm mt-2">{product.notes}</p>
-            )}
-          </div>
-          <div className="flex gap-2 shrink-0">
             <Link
               to={`/food/${productId}/edit`}
-              className="flex-1 sm:flex-none inline-flex items-center justify-center gap-1.5 px-3 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded-lg transition-colors"
+              aria-label={t('common.edit')}
+              className="inline-flex items-center justify-center p-1 text-gray-400 hover:text-white transition-colors"
             >
               <EditIcon />
-              {t('common.edit')}
             </Link>
             <button
               onClick={() => setShowDeleteProduct(true)}
-              className="flex-1 sm:flex-none inline-flex items-center justify-center gap-1.5 px-3 py-2 bg-red-800 hover:bg-red-700 text-white text-sm rounded-lg transition-colors"
+              aria-label={t('common.delete')}
+              className="inline-flex items-center justify-center p-1 text-gray-400 hover:text-red-400 transition-colors"
             >
               <TrashIcon />
-              {t('common.delete')}
             </button>
           </div>
+          {product.notes && (
+            <p className="text-gray-300 text-sm mt-2">{product.notes}</p>
+          )}
         </div>
 
         <div className="mt-4 flex items-center gap-3">

--- a/src/pages/WaterDetailPage.tsx
+++ b/src/pages/WaterDetailPage.tsx
@@ -78,32 +78,30 @@ export default function WaterDetailPage({ forceId }: Props) {
 
       {/* Product header */}
       <div className="bg-gray-800 border border-gray-700 rounded-xl p-4 sm:p-6 mb-6">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="min-w-0">
-            <h1 className="text-xl sm:text-2xl font-bold text-white">{product.name}</h1>
-            <p className="text-gray-400 text-sm mt-1">
+        <div>
+          <h1 className="text-xl sm:text-2xl font-bold text-white">{product.name}</h1>
+          <div className="flex items-center gap-2 mt-1">
+            <p className="text-gray-400 text-sm">
               {t(`categories.${product.category}`)} · {t('products.target', { qty: product.targetQuantity, unit })}
             </p>
-            {product.notes && (
-              <p className="text-gray-300 text-sm mt-2">{product.notes}</p>
-            )}
-          </div>
-          <div className="flex gap-2 shrink-0">
             <Link
               to={`/water/edit`}
-              className="flex-1 sm:flex-none inline-flex items-center justify-center gap-1.5 px-3 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded-lg transition-colors"
+              aria-label={t('common.edit')}
+              className="inline-flex items-center justify-center p-1 text-gray-400 hover:text-white transition-colors"
             >
               <EditIcon />
-              {t('common.edit')}
             </Link>
             <button
               onClick={() => setShowDeleteProduct(true)}
-              className="flex-1 sm:flex-none inline-flex items-center justify-center gap-1.5 px-3 py-2 bg-red-800 hover:bg-red-700 text-white text-sm rounded-lg transition-colors"
+              aria-label={t('common.delete')}
+              className="inline-flex items-center justify-center p-1 text-gray-400 hover:text-red-400 transition-colors"
             >
               <TrashIcon />
-              {t('common.delete')}
             </button>
           </div>
+          {product.notes && (
+            <p className="text-gray-300 text-sm mt-2">{product.notes}</p>
+          )}
         </div>
 
         <div className="mt-4 flex items-center gap-3">


### PR DESCRIPTION
## Summary
- Replaces the full-width labelled Edit/Delete button row in the product header with icon-only buttons placed inline next to the category · target label
- Applies to both `FoodDetailPage` and `WaterDetailPage`
- `aria-label` retained on both buttons for accessibility

## Test plan
- [ ] Open a food product detail page — verify edit (pencil) and delete (trash) icons appear inline after the category/target text
- [ ] Open the water detail page — same check
- [ ] Verify edit icon navigates to the edit page
- [ ] Verify delete icon opens the confirm dialog
- [ ] Check on mobile viewport that the layout looks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)