### PR TITLE
feat: true offline-first — queue all entity mutations including product CRUD

### DIFF
--- a/src/components/layout/Layout.prefetch.test.tsx
+++ b/src/components/layout/Layout.prefetch.test.tsx
@@ -9,7 +9,7 @@ import type { PendingOp } from '../../offline/db'
 vi.mock('./Navbar', () => ({ default: () => null }))
 vi.mock('./BottomTabBar', () => ({ default: () => null }))
 vi.mock('../../context/useSync', () => ({
-  useSync: () => ({ setPrefetching: vi.fn() }),
+  useSync: () => ({ setPrefetching: vi.fn(), conflicts: [], clearConflicts: vi.fn() }),
 }))
 
 const mocks = vi.hoisted(() => ({
@@ -32,6 +32,7 @@ vi.mock('../../offline/db', () => ({
   db: {
     pendingOps: {
       where: mocks.dbWhere,
+      filter: vi.fn(() => ({ sortBy: vi.fn(() => Promise.resolve([])) })),
       add: vi.fn(),
       count: vi.fn(() => Promise.resolve(0)),
     },

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,16 +1,19 @@
 import { useEffect } from 'react'
 import { Outlet } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
 import Navbar from './Navbar'
 import BottomTabBar from './BottomTabBar'
+import Toast from '../ui/Toast'
 import { makeProductsQueryFn, makeProductStockQueryFn } from '../../hooks/useProducts'
 import { useSync } from '../../context/useSync'
 import { saveQueryCache } from '../../offline/queryPersister'
 import type { Product } from '../../types'
 
 export default function Layout() {
+  const { t } = useTranslation()
   const qc = useQueryClient()
-  const { setPrefetching } = useSync()
+  const { setPrefetching, conflicts, clearConflicts } = useSync()
 
   useEffect(() => {
     setPrefetching(true)
@@ -51,6 +54,15 @@ export default function Layout() {
         <Outlet />
       </main>
       <BottomTabBar />
+      {conflicts.length > 0 && (
+        <Toast
+          message={t('sync.conflict', { count: conflicts.length })}
+          actionLabel={t('common.confirm')}
+          onAction={clearConflicts}
+          onDismiss={clearConflicts}
+          duration={8000}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -33,6 +33,17 @@ export default function Layout() {
     })
   }, [qc, setPrefetching])
 
+  // Persist the query cache whenever the app is backgrounded (e.g. user switches apps
+  // on mobile). TanStack Query background refetches keep the in-memory cache fresh but
+  // do not trigger saveQueryCache(), so without this the Dexie snapshot can be stale.
+  useEffect(() => {
+    const save = () => {
+      if (document.visibilityState === 'hidden') void saveQueryCache()
+    }
+    document.addEventListener('visibilitychange', save)
+    return () => document.removeEventListener('visibilitychange', save)
+  }, [])
+
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-gray-100">
       <Navbar />

--- a/src/context/BackendStatusProvider.tsx
+++ b/src/context/BackendStatusProvider.tsx
@@ -2,9 +2,14 @@ import { useEffect, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import client, { isBackendUnreachable } from '../api/client'
 import { BackendStatusContext } from './BackendStatusContext'
+import { useOnlineStatus } from '../hooks/useOnlineStatus'
 
 export function BackendStatusProvider({ children }: { children: React.ReactNode }) {
-  const [isOffline, setIsOffline] = useState(false)
+  // Tracks whether the backend is unreachable based on query/health-check failures.
+  // The context value also incorporates navigator.onLine so that mutations can skip
+  // the network attempt immediately when the device has no connectivity at all.
+  const [isBackendQueryOffline, setIsBackendQueryOffline] = useState(false)
+  const isOnline = useOnlineStatus()
   const queryClient = useQueryClient()
 
   useQuery({
@@ -20,16 +25,16 @@ export function BackendStatusProvider({ children }: { children: React.ReactNode 
       if (event.type !== 'updated') return
       const { state } = event.query
       if (state.status === 'error' && isBackendUnreachable(state.error)) {
-        setIsOffline(true)
+        setIsBackendQueryOffline(true)
       } else if (state.status === 'success' && event.query.queryKey[0] === '__health__') {
-        setIsOffline(false)
+        setIsBackendQueryOffline(false)
       }
     })
     return unsubscribe
   }, [queryClient])
 
   return (
-    <BackendStatusContext.Provider value={isOffline}>
+    <BackendStatusContext.Provider value={isBackendQueryOffline || !isOnline}>
       {children}
     </BackendStatusContext.Provider>
   )

--- a/src/context/SyncContext.ts
+++ b/src/context/SyncContext.ts
@@ -2,12 +2,20 @@ import { createContext } from 'react'
 
 export type SyncStatus = 'idle' | 'pending' | 'syncing' | 'synced'
 
+export interface ConflictInfo {
+  productId: number
+  productName: string
+}
+
 export interface SyncContextValue {
   status: SyncStatus
   pendingCount: number
   prefetching: boolean
   setPrefetching: (v: boolean) => void
   sync: () => Promise<void>
+  conflicts: ConflictInfo[]
+  clearConflicts: () => void
+  resolvedProductIds: Map<number, number>
 }
 
 export const SyncContext = createContext<SyncContextValue | null>(null)

--- a/src/context/SyncProvider.tsx
+++ b/src/context/SyncProvider.tsx
@@ -3,13 +3,13 @@ import { useQueryClient } from '@tanstack/react-query'
 import { liveQuery } from 'dexie'
 import { NotFoundError, ClientError } from '../api/client'
 import { SyncContext } from './SyncContext'
-import type { SyncStatus } from './SyncContext'
+import type { ConflictInfo, SyncStatus } from './SyncContext'
 import { useBackendStatus } from './useBackendStatus'
 import { useOnlineStatus } from '../hooks/useOnlineStatus'
 import { db } from '../offline/db'
 import type { PendingOp } from '../offline/db'
-import type { StockEntry, StockEntryPayload } from '../types'
-import { addStockEntry } from '../api/products'
+import type { Product, StockEntry, StockEntryPayload, ProductPayload } from '../types'
+import { addStockEntry, createProduct, getProduct, updateProduct, deleteProduct } from '../api/products'
 import { patchStockEntry, putStockEntry, deleteStockEntry } from '../api/stock'
 
 export function SyncProvider({ children }: { children: React.ReactNode }) {
@@ -21,6 +21,8 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
   const [isSyncing, setIsSyncing] = useState(false)
   const [justSynced, setJustSynced] = useState(false)
   const [isPrefetching, setIsPrefetching] = useState(false)
+  const [conflicts, setConflicts] = useState<ConflictInfo[]>([])
+  const [resolvedProductIds, setResolvedProductIds] = useState<Map<number, number>>(new Map())
   const syncInProgress = useRef(false)
 
   const status: SyncStatus = isSyncing
@@ -64,17 +66,27 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
 
     try {
       const ops = await db.pendingOps.orderBy('createdAt').toArray()
-      // Maps temp IDs (negative ints from offline ADDs) to real server IDs
+      // Maps temp stock entry IDs (negative ints) to real server IDs
       const tempIdMap = new Map<number, number>()
+      // Maps temp product IDs (negative ints) to real server IDs
+      const tempProductIdMap = new Map<number, number>()
+      const newConflicts: ConflictInfo[] = []
 
       let aborted = false
       for (const op of ops) {
-        const ok = await processSingleOp(op, tempIdMap, qc)
+        const ok = await processSingleOp(op, tempIdMap, tempProductIdMap, newConflicts, qc)
         if (!ok) { aborted = true; break }
       }
 
       await qc.invalidateQueries({ queryKey: ['products'] })
       await qc.invalidateQueries({ queryKey: ['stock'] })
+
+      if (tempProductIdMap.size > 0) {
+        setResolvedProductIds((prev) => new Map([...prev, ...tempProductIdMap]))
+      }
+      if (newConflicts.length > 0) {
+        setConflicts((prev) => [...prev, ...newConflicts])
+      }
       if (!aborted) {
         setJustSynced(true)
         setTimeout(() => setJustSynced(false), 2000)
@@ -105,8 +117,19 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
     }
   }, [isOnline, isBackendOffline])
 
+  const clearConflicts = useCallback(() => setConflicts([]), [])
+
   return (
-    <SyncContext.Provider value={{ status, pendingCount, prefetching: isPrefetching, setPrefetching: setIsPrefetching, sync }}>
+    <SyncContext.Provider value={{
+      status,
+      pendingCount,
+      prefetching: isPrefetching,
+      setPrefetching: setIsPrefetching,
+      sync,
+      conflicts,
+      clearConflicts,
+      resolvedProductIds,
+    }}>
       {children}
     </SyncContext.Provider>
   )
@@ -115,15 +138,66 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
 async function processSingleOp(
   op: PendingOp,
   tempIdMap: Map<number, number>,
-  qc: ReturnType<typeof useQueryClient>
+  tempProductIdMap: Map<number, number>,
+  conflicts: ConflictInfo[],
+  qc: ReturnType<typeof useQueryClient>,
 ): Promise<boolean> {
-  // Resolve any temp IDs that were mapped to real IDs by earlier ops in this sync session
+  // Resolve temp product IDs mapped by earlier CREATE_PRODUCT ops in this sync session
+  const resolvedProductId = tempProductIdMap.get(op.productId) ?? op.productId
+  // Resolve temp stock entry IDs mapped by earlier ADD ops in this sync session
   const resolvedEntryId =
     op.entryId !== null ? (tempIdMap.get(op.entryId) ?? op.entryId) : null
 
   try {
-    if (op.type === 'ADD') {
-      const result = await addStockEntry(op.productId, op.payload as StockEntryPayload)
+    if (op.type === 'CREATE_PRODUCT') {
+      const result = await createProduct(op.payload as ProductPayload)
+      if (op.tempId !== null) {
+        tempProductIdMap.set(op.tempId, result.id)
+
+        // Update all dependent ops (both stock and product UPDATE/DELETE) that reference this temp product ID
+        const dependentOps = await db.pendingOps.where('productId').equals(op.tempId).toArray()
+        for (const dop of dependentOps) {
+          await db.pendingOps.update(dop.id!, { productId: result.id })
+        }
+
+        // Move product list cache entry from tempId to realId
+        qc.setQueryData<Product[]>(['products', null], (old) => {
+          if (!old) return old
+          return old.map((p) => (p.id === op.tempId ? { ...p, id: result.id } : p))
+        })
+        // Set the individual product cache entry under the real ID
+        qc.setQueryData(['products', result.id], result)
+        qc.removeQueries({ queryKey: ['products', op.tempId] })
+
+        // Move stock cache from temp product ID to real product ID
+        const tempStock = qc.getQueryData<StockEntry[]>(['products', op.tempId, 'stock'])
+        if (tempStock) {
+          qc.setQueryData(['products', result.id, 'stock'], tempStock)
+          qc.removeQueries({ queryKey: ['products', op.tempId, 'stock'] })
+        }
+      }
+    } else if (op.type === 'UPDATE_PRODUCT') {
+      // Conflict detection: compare stored snapshot with current server state
+      if (op.beforeSnapshot && resolvedProductId > 0) {
+        try {
+          const current = await getProduct(resolvedProductId)
+          const snapshot = op.beforeSnapshot as Product
+          if (
+            current.name !== snapshot.name ||
+            current.targetQuantity !== snapshot.targetQuantity ||
+            current.notes !== snapshot.notes
+          ) {
+            conflicts.push({ productId: resolvedProductId, productName: current.name })
+          }
+        } catch {
+          // If fetching current state fails, skip conflict detection and proceed
+        }
+      }
+      await updateProduct(resolvedProductId, op.payload as ProductPayload)
+    } else if (op.type === 'DELETE_PRODUCT') {
+      await deleteProduct(resolvedProductId)
+    } else if (op.type === 'ADD') {
+      const result = await addStockEntry(resolvedProductId, op.payload as StockEntryPayload)
       if (op.tempId !== null) {
         tempIdMap.set(op.tempId, result.id)
 
@@ -133,11 +207,10 @@ async function processSingleOp(
           await db.pendingOps.update(dop.id!, { entryId: result.id })
         }
 
-        // Update the query cache directly to switch the tempId to the real ID.
-        // This ensures optimistic UI doesn't lose the item if a later fetch fails.
-        qc.setQueryData<StockEntry[]>(['products', op.productId, 'stock'], (old) => {
+        // Update the query cache directly to switch the tempId to the real ID
+        qc.setQueryData<StockEntry[]>(['products', resolvedProductId, 'stock'], (old) => {
           if (!old) return old
-          return old.map(entry => entry.id === op.tempId ? { ...entry, id: result.id } : entry)
+          return old.map((entry) => (entry.id === op.tempId ? { ...entry, id: result.id } : entry))
         })
       }
     } else if (op.type === 'PATCH') {
@@ -150,7 +223,7 @@ async function processSingleOp(
     await db.pendingOps.delete(op.id!)
     return true
   } catch (e) {
-    // 404 means the target resource is gone and the op can never succeed — discard it.
+    // 404 means the target resource is gone and the op can never succeed — discard it
     if (e instanceof NotFoundError) {
       await db.pendingOps.delete(op.id!)
       console.warn('[SyncProvider] op discarded (resource not found)', op)

--- a/src/hooks/useProducts.offlineFallback.test.tsx
+++ b/src/hooks/useProducts.offlineFallback.test.tsx
@@ -26,6 +26,7 @@ vi.mock('../offline/db', () => ({
   db: {
     pendingOps: {
       where: mocks.dbWhere,
+      filter: vi.fn(() => ({ sortBy: vi.fn(() => Promise.resolve([])) })),
       add: vi.fn(),
       count: vi.fn(() => Promise.resolve(0)),
     },

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -12,26 +12,49 @@ import type { Category, Product, ProductPayload, StockEntry, StockEntryPayload }
 import { useBackendStatus } from '../context/useBackendStatus'
 import { isBackendUnreachable } from '../api/client'
 import { db } from '../offline/db'
-import { applyOpsToCache } from '../offline/applyOpsToCache'
+import { applyOpsToCache, applyProductOpsToCache } from '../offline/applyOpsToCache'
 import { saveQueryCache } from '../offline/queryPersister'
+
+const PRODUCT_OP_TYPES = ['CREATE_PRODUCT', 'UPDATE_PRODUCT', 'DELETE_PRODUCT'] as const
+
+async function getPendingProductOps() {
+  return db.pendingOps
+    .filter((op) => (PRODUCT_OP_TYPES as readonly string[]).includes(op.type))
+    .sortBy('createdAt')
+}
 
 export function makeProductsQueryFn(category: Category | undefined, qc: ReturnType<typeof useQueryClient>) {
   return async () => {
+    let products: Product[]
     try {
-      return await getProducts(category)
+      products = await getProducts(category)
     } catch (e) {
       if (!isBackendUnreachable(e)) throw e
+      // Offline fallback: strip any temp ID products from cache — they'll be re-applied from pending ops
       const prev = qc.getQueryData<Product[]>(['products', category ?? null])
-      if (prev) return prev
-      // Scan all product list caches and filter by category
-      const allQueries = qc.getQueriesData<Product[]>({ queryKey: ['products'] })
-      for (const [, data] of allQueries) {
-        if (Array.isArray(data) && data.length > 0) {
-          return category ? data.filter((p) => p.category === category) : data
+      if (prev) {
+        products = prev.filter((p) => p.id > 0)
+      } else {
+        products = []
+        const allQueries = qc.getQueriesData<Product[]>({ queryKey: ['products'] })
+        for (const [, data] of allQueries) {
+          if (Array.isArray(data) && data.length > 0) {
+            products = data.filter((p) => p.id > 0)
+            if (category) products = products.filter((p) => p.category === category)
+            break
+          }
         }
       }
-      return []
     }
+
+    // Always apply pending product ops so offline-created/edited/deleted products are visible
+    const ops = await getPendingProductOps()
+    if (ops.length > 0) {
+      products = applyProductOpsToCache(products, ops)
+      if (category) products = products.filter((p) => p.category === category)
+    }
+
+    return products
   }
 }
 
@@ -48,6 +71,28 @@ export const useProduct = (id: number) => {
   return useQuery({
     queryKey: ['products', id],
     queryFn: async () => {
+      // Temp ID: construct product from the CREATE_PRODUCT pending op
+      if (id < 0) {
+        const ops = await db.pendingOps
+          .filter((op) => (PRODUCT_OP_TYPES as readonly string[]).includes(op.type) && op.productId === id)
+          .sortBy('createdAt')
+        const createOp = ops.find((op) => op.type === 'CREATE_PRODUCT')
+        if (!createOp) return undefined
+        const p = createOp.payload as ProductPayload
+        const base: Product = {
+          id,
+          name: p.name,
+          category: p.category,
+          unit: p.unit,
+          targetQuantity: p.targetQuantity,
+          currentStock: 0,
+          notes: p.notes ?? null,
+        }
+        // Apply any subsequent UPDATE ops on this temp product
+        const [result] = applyProductOpsToCache([base], ops.filter((op) => op.type !== 'CREATE_PRODUCT'))
+        return result ?? base
+      }
+
       try {
         return await getProduct(id)
       } catch (e) {
@@ -73,7 +118,12 @@ export function makeProductStockQueryFn(id: number, qc: ReturnType<typeof useQue
   return async () => {
     let serverData: StockEntry[]
     try {
-      serverData = await getProductStock(id)
+      // Temp product IDs have no server stock yet — start from empty
+      if (id < 0) {
+        serverData = []
+      } else {
+        serverData = await getProductStock(id)
+      }
     } catch (e) {
       if (!isBackendUnreachable(e)) throw e
       // Backend unreachable — fall back to last known server state, stripping
@@ -97,8 +147,35 @@ export const useProductStock = (id: number) => {
 
 export const useCreateProduct = () => {
   const qc = useQueryClient()
+  const isOffline = useBackendStatus()
   return useMutation({
-    mutationFn: (payload: ProductPayload) => createProduct(payload),
+    mutationFn: async (payload: ProductPayload): Promise<Product> => {
+      if (!isOffline) {
+        try {
+          return await createProduct(payload)
+        } catch (e) {
+          if (!isBackendUnreachable(e)) throw e
+        }
+      }
+      const tempId = -Date.now()
+      await db.pendingOps.add({
+        type: 'CREATE_PRODUCT',
+        productId: tempId,
+        entryId: null,
+        tempId,
+        payload,
+        createdAt: Date.now(),
+      })
+      return {
+        id: tempId,
+        name: payload.name,
+        category: payload.category,
+        unit: payload.unit,
+        targetQuantity: payload.targetQuantity,
+        currentStock: 0,
+        notes: payload.notes ?? null,
+      }
+    },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['products'] })
       saveQueryCache()
@@ -108,8 +185,37 @@ export const useCreateProduct = () => {
 
 export const useUpdateProduct = (id: number) => {
   const qc = useQueryClient()
+  const isOffline = useBackendStatus()
   return useMutation({
-    mutationFn: (payload: ProductPayload) => updateProduct(id, payload),
+    mutationFn: async (payload: ProductPayload): Promise<Product> => {
+      if (!isOffline) {
+        try {
+          return await updateProduct(id, payload)
+        } catch (e) {
+          if (!isBackendUnreachable(e)) throw e
+        }
+      }
+      // Store current state for conflict detection (only meaningful for real server IDs)
+      const beforeSnapshot = id > 0 ? qc.getQueryData<Product>(['products', id]) : undefined
+      await db.pendingOps.add({
+        type: 'UPDATE_PRODUCT',
+        productId: id,
+        entryId: null,
+        tempId: null,
+        payload,
+        beforeSnapshot,
+        createdAt: Date.now(),
+      })
+      return {
+        id,
+        name: payload.name,
+        category: payload.category,
+        unit: payload.unit,
+        targetQuantity: payload.targetQuantity,
+        currentStock: qc.getQueryData<Product>(['products', id])?.currentStock ?? 0,
+        notes: payload.notes ?? null,
+      }
+    },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['products'] })
       saveQueryCache()
@@ -119,8 +225,26 @@ export const useUpdateProduct = (id: number) => {
 
 export const useDeleteProduct = () => {
   const qc = useQueryClient()
+  const isOffline = useBackendStatus()
   return useMutation({
-    mutationFn: (id: number) => deleteProduct(id),
+    mutationFn: async (id: number): Promise<void> => {
+      if (!isOffline) {
+        try {
+          await deleteProduct(id)
+          return
+        } catch (e) {
+          if (!isBackendUnreachable(e)) throw e
+        }
+      }
+      await db.pendingOps.add({
+        type: 'DELETE_PRODUCT',
+        productId: id,
+        entryId: null,
+        tempId: null,
+        payload: null,
+        createdAt: Date.now(),
+      })
+    },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['products'] })
       qc.invalidateQueries({ queryKey: ['stock'] })

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -50,6 +50,7 @@ const en = {
     expires: 'Expires {{date}}',
     category_breakdown: 'By category',
     category_at_target: '{{count}}/{{total}} at target',
+    offline_notice: 'Status data (expired, stock levels etc.) may be outdated while offline.',
   },
   products: {
     page_title: 'Food',
@@ -207,6 +208,9 @@ const en = {
     loading: 'Loading…',
     syncing: 'Syncing…',
     synced: 'Synced',
+    conflict_one: 'Sync conflict — your changes were saved over a newer version',
+    conflict_other: '{{count}} sync conflicts — your changes were saved over newer versions',
+    conflict: 'Sync conflict — your changes were saved over a newer version',
   },
 } as const
 

--- a/src/i18n/locales/sv.ts
+++ b/src/i18n/locales/sv.ts
@@ -50,6 +50,7 @@ const sv = {
     expires: 'Bäst före {{date}}',
     category_breakdown: 'Per kategori',
     category_at_target: '{{count}}/{{total}} på mål',
+    offline_notice: 'Statusdata (utgångna, lagernivåer m.m.) kan vara inaktuell i offlineläge.',
   },
   products: {
     page_title: 'Mat',
@@ -207,6 +208,9 @@ const sv = {
     loading: 'Laddar…',
     syncing: 'Synkar…',
     synced: 'Synkat',
+    conflict_one: 'Synkkonflikt — dina ändringar sparades över en nyare version',
+    conflict_other: '{{count}} synkkonflikter — dina ändringar sparades över nyare versioner',
+    conflict: 'Synkkonflikt — dina ändringar sparades över en nyare version',
   },
 } as const
 

--- a/src/offline/applyOpsToCache.ts
+++ b/src/offline/applyOpsToCache.ts
@@ -1,4 +1,4 @@
-import type { StockEntry, StockEntryPayload } from '../types'
+import type { Product, ProductPayload, StockEntry, StockEntryPayload } from '../types'
 import type { PendingOp } from './db'
 
 /**
@@ -47,6 +47,43 @@ export function applyOpsToCache(entries: StockEntry[], ops: PendingOp[]): StockE
       result = result.filter((e) => e.id !== op.entryId)
     } else {
       console.error('[applyOpsToCache] Unrecognised or malformed op, skipping', op)
+    }
+  }
+
+  return result
+}
+
+/**
+ * Applies pending offline product ops to a cached product array, producing the locally-correct view.
+ * Used in useProducts query fns so offline-created/edited/deleted products are immediately visible.
+ */
+export function applyProductOpsToCache(products: Product[], ops: PendingOp[]): Product[] {
+  let result = [...products]
+
+  for (const op of ops) {
+    if (op.type === 'CREATE_PRODUCT' && op.tempId !== null) {
+      const p = op.payload as ProductPayload
+      result = [
+        ...result,
+        {
+          id: op.tempId,
+          name: p.name,
+          category: p.category,
+          unit: p.unit,
+          targetQuantity: p.targetQuantity,
+          currentStock: 0,
+          notes: p.notes ?? null,
+        },
+      ]
+    } else if (op.type === 'UPDATE_PRODUCT') {
+      const p = op.payload as ProductPayload
+      result = result.map((product) =>
+        product.id === op.productId
+          ? { ...product, name: p.name, category: p.category, unit: p.unit, targetQuantity: p.targetQuantity, notes: p.notes ?? null }
+          : product,
+      )
+    } else if (op.type === 'DELETE_PRODUCT') {
+      result = result.filter((product) => product.id !== op.productId)
     }
   }
 

--- a/src/offline/db.ts
+++ b/src/offline/db.ts
@@ -2,11 +2,12 @@ import Dexie, { type Table } from 'dexie'
 
 export interface PendingOp {
   id?: number
-  type: 'ADD' | 'PATCH' | 'UPDATE' | 'DELETE'
-  productId: number    // for hydration — which cache key to update
+  type: 'ADD' | 'PATCH' | 'UPDATE' | 'DELETE' | 'CREATE_PRODUCT' | 'UPDATE_PRODUCT' | 'DELETE_PRODUCT'
+  productId: number    // for hydration — which cache key to update; also the temp product ID for CREATE_PRODUCT ops
   entryId: number | null  // server ID or temp ID for subsequent ops on offline-added entries
-  tempId: number | null   // negative int assigned to ADD ops, resolved to real ID during sync
-  payload: unknown     // StockEntryPayload | { quantity: number } | null
+  tempId: number | null   // negative int: for ADD ops = stock entry tempId, for CREATE_PRODUCT = product tempId
+  payload: unknown     // StockEntryPayload | ProductPayload | { quantity: number } | null
+  beforeSnapshot?: unknown  // snapshot of entity at time of queuing, used for conflict detection on UPDATE ops
   createdAt: number
 }
 

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { useExpiredStock, useExpiringStock, useLowStock } from '../hooks/useStock'
 import { useProducts } from '../hooks/useProducts'
+import { useBackendStatus } from '../context/useBackendStatus'
 import type { StockEntry, Product } from '../types'
 import { NO_EXPIRY_DATE } from '../types'
 import { Link } from 'react-router-dom'
@@ -68,6 +69,7 @@ function LowStockRow({ product }: { product: Product }) {
 
 export default function DashboardPage() {
   const { t } = useTranslation()
+  const isOffline = useBackendStatus()
   const { data: expired = [], isLoading: l1 } = useExpiredStock()
   const { data: expiring = [], isLoading: l2 } = useExpiringStock()
   const { data: low = [], isLoading: l3 } = useLowStock()
@@ -95,6 +97,16 @@ export default function DashboardPage() {
 
   return (
     <div className="space-y-8">
+      {isOffline && (
+        <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-amber-700 dark:text-amber-400 text-sm">
+          <svg aria-hidden="true" className="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+          {t('dashboard.offline_notice')}
+        </div>
+      )}
       <PreparednessRating products={products} expired={expired} />
 
       {expired.length > 0 && (

--- a/src/pages/FoodDetailPage.tsx
+++ b/src/pages/FoodDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate, useParams, Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useProduct, useProductStock, useDeleteProduct, useAddStockEntry } from '../hooks/useProducts'
@@ -6,6 +6,7 @@ import { usePatchStock, useDeleteStock, useUpdateStock } from '../hooks/useStock
 import type { StockEntry, StockEntryPayload } from '../types'
 import { useUndoStockDelete } from '../hooks/useUndoStockDelete'
 import { usePendingOps } from '../hooks/usePendingOps'
+import { useSync } from '../context/useSync'
 import StockEntryRow from '../components/stock/StockEntryRow'
 import { formatNumber } from '../components/stock/unitStep'
 import StockEntryForm from '../components/stock/StockEntryForm'
@@ -49,6 +50,16 @@ export default function FoodDetailPage({ forceId }: Props) {
   const { id } = useParams<{ id: string }>()
   const productId = forceId ?? Number(id)
   const navigate = useNavigate()
+
+  const { resolvedProductIds } = useSync()
+
+  // When a temp-ID product is synced, redirect to the real URL
+  useEffect(() => {
+    if (productId < 0) {
+      const realId = resolvedProductIds.get(productId)
+      if (realId !== undefined) navigate(`/food/${realId}`, { replace: true })
+    }
+  }, [productId, resolvedProductIds, navigate])
 
   const { data: product, isLoading: pLoading, isError: pError } = useProduct(productId)
   const { data: stock = [], isLoading: sLoading } = useProductStock(productId)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,11 +35,16 @@ export default defineConfig({
         runtimeCaching: [
           {
             // Health check: always hit the network, never serve from cache
-            urlPattern: ({ url }) => url.pathname.startsWith('/api/') && url.searchParams.has('__nc'),
+            urlPattern: ({ url, request }) =>
+              url.pathname.startsWith('/api/') && url.searchParams.has('__nc') && request.method === 'GET',
             handler: 'NetworkOnly',
           },
           {
-            urlPattern: ({ url }) => url.pathname.startsWith('/api/'),
+            // Only cache GET responses — mutations (POST/PATCH/PUT/DELETE) must not be
+            // subject to the networkTimeoutSeconds delay, as there is no cached response
+            // to fall back to and the 10 s timeout would freeze the UI in poor connectivity.
+            urlPattern: ({ url, request }) =>
+              url.pathname.startsWith('/api/') && request.method === 'GET',
             handler: 'NetworkFirst',
             options: {
               cacheName: 'api-cache',


### PR DESCRIPTION
## Summary

- **Product CRUD now works offline**: create, edit, and delete products are queued to Dexie when the backend is unreachable, exactly like stock-entry mutations already were
- **Temp product IDs**: offline-created products get a negative temp ID; navigating to `/food/-1234` works normally, and `FoodDetailPage` auto-redirects to the real URL once the `CREATE_PRODUCT` op syncs
- **Cascading temp ID resolution**: when a `CREATE_PRODUCT` op syncs, all dependent stock-entry ops have their `productId` updated to the real ID before they are processed
- **Conflict detection**: `UPDATE_PRODUCT` ops fetch the current server state before the PUT and compare against a `beforeSnapshot` stored at queue time; if the server version differs, a dismissible Toast is shown (last-write-wins)
- **Dashboard offline notice**: amber banner on the Dashboard while offline, explaining that expired/expiring/low-stock data may be stale (those endpoints remain online-only)

## Changed files

| File | Change |
|------|--------|
| `src/offline/db.ts` | `CREATE_PRODUCT`, `UPDATE_PRODUCT`, `DELETE_PRODUCT` op types; `beforeSnapshot` field |
| `src/offline/applyOpsToCache.ts` | New `applyProductOpsToCache` function |
| `src/context/SyncContext.ts` | `ConflictInfo`, `conflicts`, `clearConflicts`, `resolvedProductIds` |
| `src/context/SyncProvider.tsx` | Handles 3 new op types, temp product ID cascading, conflict detection |
| `src/hooks/useProducts.ts` | Offline fallbacks for all 3 product mutations; product ops applied in query fns |
| `src/pages/FoodDetailPage.tsx` | Redirect effect for temp-ID → real-ID after sync |
| `src/pages/DashboardPage.tsx` | Amber offline notice banner |
| `src/components/layout/Layout.tsx` | Conflict Toast |
| `src/i18n/locales/sv.ts` + `en.ts` | `dashboard.offline_notice`, `sync.conflict` keys |
| Test mocks | `filter()` added to `db.pendingOps` mock; `useSync` mock updated |

## Test plan

- [ ] Create a product while offline → appears in list and detail page immediately
- [ ] Add stock to the offline-created product → also queued correctly
- [ ] Reconnect → both `CREATE_PRODUCT` and stock `ADD` ops sync in order; product appears with real ID; page redirects from `/food/-tempId` to `/food/realId`
- [ ] Edit an existing product while offline → update queued; product shows edited name immediately
- [ ] Edit a product offline that was also edited on the server → conflict Toast appears after sync
- [ ] Delete a product offline → disappears from list immediately; deletion syncs on reconnect
- [ ] Go to Dashboard while offline → amber notice banner visible; prep rating still shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)